### PR TITLE
修复了两个在Win简体中文环境下的错误

### DIFF
--- a/Config.py
+++ b/Config.py
@@ -33,7 +33,7 @@ class Config:
 
     async def load_ark(self,ark = ""):
         ark_path = os.path.join(FILE_PATH,"ARK")
-        with open(os.path.join(ark_path,"{}.json".format(ark)),'r') as load_f:
+        with open(os.path.join(ark_path,"{}.json".format(ark)),'r', encoding="utf-8") as load_f:
             im = json.load(load_f)
         return im
         

--- a/bot.py
+++ b/bot.py
@@ -178,7 +178,7 @@ async def _message_handler(event, message: Message):
     try:
         guild_data = await guild_api.get_guild(message.guild_id)
         at_mes = re.search(r'\<\@\![0-9]+\>',message.content)
-        raw_mes = message.content.replace(at_mes.group(),"").replace(" ","").replace("/","")
+        raw_mes = message.content.replace(at_mes.group(),"").replace(" ","").replace("/","").strip()
         record_mes = raw_mes
     except Exception as e:
         qqbot.logger.info(e.with_traceback)


### PR DESCRIPTION
1. QQ频道PC客户端的at消息会带上一个NBSP（0xa0，而不是0x20），导致简单替换失效，这里在末尾加上了`.strip()`（看上去有点怪怪的，有没有更好的写法？是不是直接把replace空格删掉更好？）。
2. 读取ARK/*.json未指定编码，在默认编码不是UTF-8的环境下会有异常（说的就是你，Windows）。