### PR TITLE
fix multi connection bug with asyncio lock

### DIFF
--- a/GenshinUID/__init__.py
+++ b/GenshinUID/__init__.py
@@ -43,7 +43,7 @@ __plugin_meta__ = PluginMetadata(
 )
 
 gsclient: Optional[GsClient] = None
-is_connecting = False
+connect_lock = asyncio.Lock()
 command_start = deepcopy(driver.config.command_start)
 command_start.discard('')
 msg_id_cache = OrderedDict()
@@ -315,12 +315,8 @@ async def get_notice_message(bot: Bot, ev: Event):
 
 @get_message.handle()
 async def get_all_message(bot: Bot, ev: Event):
-    global is_connecting
-    if is_connecting:
-        return
 
-    if gsclient is None and is_connecting is False:
-        is_connecting = True
+    if gsclient is None:
         return await connect()
 
     try:
@@ -759,14 +755,19 @@ async def start_client():
 
 async def connect():
     global gsclient
-    try:
-        await asyncio.sleep(2)
-        gsclient = await GsClient().async_connect()
-        await gsclient.start()
-    except ConnectionRefusedError:
-        global is_connecting
-        is_connecting = False
-        logger.error('Core服务器连接失败...请稍后使用[启动core]命令启动...')
+
+    async with connect_lock:
+        if gsclient is not None:
+            return
+        try:
+            await asyncio.sleep(2)
+            gsclient = await GsClient().async_connect()
+
+            await gsclient.start()
+
+        except ConnectionRefusedError:
+            gsclient = None
+            logger.error('Core服务器连接失败...请稍后使用[启动core]命令启动...')
 
 
 @scheduler.scheduled_job('cron', second='*/10')


### PR DESCRIPTION
### 报错：

![屏幕截图 2025-05-25 215113](https://github.com/user-attachments/assets/68bc8030-f29c-4eb5-89b2-d2043876963d)

且gs端观察到同一个Bot触发了多次链接，至多曾触发五次连接及以上，每次连接次数不定。有时连着十几次重启Bot都无法正常连接gscore

并非我一人报错，群友：
![image](https://github.com/user-attachments/assets/402f5fb8-c712-4901-a8c7-7d5bcc224471)

还有issue（这个不是我）[nb端插件链接bug · Issue #683 · KimigaiiWuyi/GenshinUID](https://github.com/KimigaiiWuyi/GenshinUID/issues/683)

### 观察1：

通过在recv处添加锁，即

```python
async def recv_msg(self):
    try:
        await asyncio.sleep(5)
        _refresh_bots()
        async with self._recv_lock:  # 避免多个协程并发调用 .recv()
            async for message in self.ws:
                ...
    except Exception as e:
        logger.exception(e)
```

观察到在每个连接的线程上都锁住了，没有一个能正常通信。

### 观察2：

活跃的bot特别容易出现报错，也就是说报错疑似与正在收发消息有关

### 疑似原因与解决：

文件位置`GenshinUID/GenshinUID/__init__.py`

```python
# line 762
async def connect():
    global gsclient
    try:
        await asyncio.sleep(2)
        gsclient = await GsClient().async_connect()
        await gsclient.start()
    except ConnectionRefusedError:
        global is_connecting
        is_connecting = False
        logger.error('Core服务器连接失败...请稍后使用[启动core]命令启动...')
```

除了开机启动，connect函数会在如下地方触发：

```python
# line 318
@get_message.handle()
async def get_all_message(bot: Bot, ev: Event):
    global is_connecting
    if is_connecting:
        return

    if gsclient is None and is_connecting is False:
        is_connecting = True
        return await connect()

    try:
        await gsclient.ws.ping()
    except ConnectionClosed:
        return await connect()
```

也就是说，如果bot connect瞬间正在接收大量消息，会由，get_all_message同时多次触发connect()，而is_connecting并不严格，无法处理竞争关系

拟解决：使用高级点的锁，并通过创建后台任务避免在锁中阻塞，由于此时锁关系全部由connect_lock解决，实际commit中移除了`is_connecting`，并改回`await gsclient.start()`。原本创建后台是因为需要设置is_connecting。

```python
connect_lock = asyncio.Lock()

...

async def connect():
    global gsclient, is_connecting

    async with connect_lock:
        if gsclient is not None:
            return
        is_connecting = True
        try:
            await asyncio.sleep(2)
            gsclient = await GsClient().async_connect()

            asyncio.create_task(gsclient.start())

            await asyncio.sleep(0.5)

            logger.success('Core服务器连接已启动，后台运行中...')
        except ConnectionRefusedError:
            gsclient = None
            logger.error('Core服务器连接失败...请稍后使用[启动core]命令启动...')
        finally:
            is_connecting = False
```

多次测试，已经解决。Bot：小维