### PR TITLE
Update __init__.py

### DIFF
--- a/GenshinUID/__init__.py
+++ b/GenshinUID/__init__.py
@@ -40,7 +40,7 @@ async def get_gs_msg(ev):
     # 通用字段获取
     user_id = str(ev.user_id)
     msg_id = str(ev.message_id)
-    group_id = str(ev.group_id)
+    group_id = str(ev.group_id) if hasattr(ev, 'group_id') and ev.group_id else ''
     self_id = str(ev.self_id)
     sender = ev.sender
     sender['avatar'] = f'http://q1.qlogo.cn/g?b=qq&nk={user_id}&s=640'
@@ -102,7 +102,8 @@ async def get_gs_msg(ev):
 
 @hoshino_bot.on_message('private')
 async def send_priv_msg(ctx):
-    ctx.group_id = ''
+    # 直接传递私聊消息，不需要修改 group_id
+    # 私聊消息的 group_id 本来就是空的或 None
     await get_gs_msg(ctx)
 
 


### PR DESCRIPTION
send_priv_msg 函数试图修改 ctx 对象的 group_id 属性，但该属性是只读的

修改：
删除了有问题的代码行：# ctx.group_id = ''

在 get_gs_msg 函数中添加了对 group_id 的安全处理：

group_id = str(ev.group_id) if hasattr(ev, 'group_id') and ev.group_id else '' 保持 send_priv_msg 函数简洁：直接传递私聊消息，不需要修改任何属性

这样修改后，私聊消息应该能正常处理了，因为私聊消息的 group_id 本来就是空的或 None，不需要手动设置