### PR TITLE
处理Windows服务器开了Clash Verge的情况下，查询角色面板报错的问题。

### DIFF
--- a/GenshinUID/genshinuid_enka/draw_normal.py
+++ b/GenshinUID/genshinuid_enka/draw_normal.py
@@ -1,5 +1,7 @@
+import httpx
 import math
 import random
+import logging
 from io import BytesIO
 from typing import Dict, Optional
 
@@ -36,6 +38,9 @@ from ..utils.resource.RESOURCE_PATH import (
     CU_CHBG_PATH,
     GACHA_IMG_PATH,
 )
+
+# 添加 logger
+logger = logging.getLogger(__name__)
 
 ARTIFACTS_POS = {
     "生之花": (13, 1087),
@@ -172,15 +177,6 @@ async def get_char_card_base(char: Character) -> Image.Image:
     )
     affix_pic = await get_weapon_affix_pic(weaponAffix)
     char_info_1.paste(affix_pic, (420 + len(weaponName) * 50, 660), affix_pic)
-    """
-    char_info_text.text(
-        (517, 895),
-        f'精炼{str(weaponAffix)}阶',
-        (255, 239, 173),
-        gs_font_28,
-        anchor='lm',
-    )
-    """
 
     weaponEffect = strLenth(weaponEffect, 25, 455)
     weaponEffect = "\n".join(weaponEffect.split("\n")[:5])
@@ -373,39 +369,87 @@ async def get_bg_card(char_element: str, ex_len: int, char_img: Image.Image) -> 
 
 async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image.Image:
     char_name = char.char_name
+    
+    # 如果启用了随机图片且没有指定URL
     if gsconfig.get_config("RandomPic").data and char_url is None:
         if char_name == "旅行者":
             char_name_url = "荧"
         else:
             char_name_url = char_name
+        
         chbg_path = CU_CHBG_PATH / char_name_url
         char_url = f"{PIC_API}{char_name_url}"
+        
+        # 如果本地有缓存图片，直接使用
         if chbg_path.exists():
             cuch_img = random.choice(list(chbg_path.iterdir()))
             async with aiofiles.open(cuch_img, "rb") as f:
                 char.char_bytes = await f.read()
         else:
-            char_data = get(char_url, follow_redirects=True)
-            if "application/json" in char_data.headers["Content-Type"]:
+            # 第一次请求：获取图片列表
+            try:
+                # 创建一个新的客户端，避免代理问题
+                with httpx.Client(verify=False, follow_redirects=True, timeout=30.0) as client:
+                    char_data = client.get(char_url)
+                
+                if char_data.status_code == 200:
+                    content_type = char_data.headers.get("Content-Type", "")
+                    if "application/json" in content_type:
+                        logger.info(f"[角色图片] {char_name} 返回JSON，可能是API问题")
+                        char_url = None
+                    else:
+                        char.char_bytes = char_data.content
+                else:
+                    logger.error(f"[角色图片] {char_name} HTTP {char_data.status_code}")
+                    char_url = None
+            except Exception as e:
+                logger.error(f"[角色图片] {char_name} 获取失败: {e}")
                 char_url = None
-            else:
-                char.char_bytes = char_data.content
 
     based_w, based_h = 600, 1200
-    if char_url:
-        offset_x, offset_y = 200, 0
-        if char.char_bytes is None:
-            char.char_bytes = get(char_url).content
-        char_img = Image.open(BytesIO(char.char_bytes)).convert("RGBA")
+    offset_x, offset_y = 200, 0
+    
+    # 如果还没有图片数据，尝试下载或使用本地图片
+    if char_url and char.char_bytes is None:
+        try:
+            # 第二次请求：下载实际图片
+            with httpx.Client(verify=False, follow_redirects=True, timeout=30.0) as client:
+                response = client.get(char_url)
+            
+            if response.status_code == 200:
+                char.char_bytes = response.content
+                logger.info(f"[角色图片] {char_name} 下载成功")
+            else:
+                logger.error(f"[角色图片] {char_name} 下载失败: HTTP {response.status_code}")
+                char_url = None
+        except Exception as e:
+            logger.error(f"[角色图片] {char_name} 下载异常: {e}")
+            char_url = None
+    
+    # 处理图片
+    if char_url and char.char_bytes is not None:
+        try:
+            char_img = Image.open(BytesIO(char.char_bytes)).convert("RGBA")
+        except Exception as e:
+            logger.error(f"[角色图片] {char_name} 解析失败: {e}")
+            char_img = None
     else:
-        offset_x, offset_y = 200, 0
+        char_img = None
+    
+    # 如果图片获取失败，使用本地缓存或创建默认图片
+    if char_img is None:
         gacha_path = GACHA_IMG_PATH / f"{char_name}.png"
         if gacha_path.exists():
-            char_img = Image.open(gacha_path)  # 角色图像
+            char_img = Image.open(gacha_path).convert("RGBA")
+            logger.info(f"[角色图片] {char_name} 使用本地缓存")
         else:
-            char_img = Image.new("RGBA", (2048, 1024))
+            # 创建默认图片
+            char_img = Image.new("RGBA", (2048, 1024), (50, 50, 50, 255))
+            draw = ImageDraw.Draw(char_img)
+            draw.text((1024, 512), char_name, fill=(255, 255, 255), anchor="mm", font=gs_font_40)
+            logger.warning(f"[角色图片] {char_name} 使用默认图片")
 
-    # 确定图片的长宽
+    # 调整图片大小和裁剪
     w, h = char_img.size
     if (w, h) != (based_w, based_h):
         based_new_w, based_new_h = based_w + offset_x, based_h + offset_y
@@ -413,6 +457,7 @@ async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image
         scale_f = "%.3f" % (w / h)
         new_w = math.ceil(based_new_h * float(scale_f))
         new_h = math.ceil(based_new_w / float(scale_f))
+        
         if scale_f > based_scale:
             bg_img2 = char_img.resize((new_w, based_new_h), Image.Resampling.LANCZOS)
             x1 = new_w / 2 - based_new_w / 2 + offset_x
@@ -425,11 +470,14 @@ async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image
             y1 = new_h / 2 - based_new_h / 2 + offset_y / 2
             x2 = based_new_w
             y2 = new_h / 2 + based_new_h / 2 - offset_y / 2
-        char_img = bg_img2.crop((x1, y1, x2, y2))  # type: ignore
+        
+        char_img = bg_img2.crop((x1, y1, x2, y2))
 
+    # 应用遮罩
     char_info_mask = Image.open(TEXT_PATH / "char_info_mask.png")
     char_result = Image.new("RGBA", (based_w, based_h), (0, 0, 0, 0))
     char_result.paste(char_img, (0, 0), char_info_mask)
+    
     return char_result
 
 
@@ -460,15 +508,6 @@ async def _get_single_artifact_img(aritifact: Dict) -> Image.Image:
         gs_font_22,
         anchor="lm",
     )
-    """
-    artifacts_text.text(
-        (30, 102),
-        artifactsPos,
-        (255, 255, 255),
-        gs_font_20,
-        anchor='lm',
-    )
-    """
 
     mainValue: float = aritifact["reliquaryMainstat"]["statValue"]
     mainName: str = aritifact["reliquaryMainstat"]["statName"]

--- a/GenshinUID/genshinuid_enka/draw_normal.py
+++ b/GenshinUID/genshinuid_enka/draw_normal.py
@@ -1,13 +1,12 @@
-import httpx
 import math
 import random
 import logging
 from io import BytesIO
 from typing import Dict, Optional
 
+import httpx
 import aiofiles
 from PIL import Image, ImageDraw, ImageChops
-from httpx import get
 
 from .etc.etc import TEXT_PATH, strLenth, get_artifacts_value
 from .etc.MAP_PATH import COLOR_MAP, avatarName2SkillAdd
@@ -369,17 +368,17 @@ async def get_bg_card(char_element: str, ex_len: int, char_img: Image.Image) -> 
 
 async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image.Image:
     char_name = char.char_name
-    
+
     # 如果启用了随机图片且没有指定URL
     if gsconfig.get_config("RandomPic").data and char_url is None:
         if char_name == "旅行者":
             char_name_url = "荧"
         else:
             char_name_url = char_name
-        
+
         chbg_path = CU_CHBG_PATH / char_name_url
         char_url = f"{PIC_API}{char_name_url}"
-        
+
         # 如果本地有缓存图片，直接使用
         if chbg_path.exists():
             cuch_img = random.choice(list(chbg_path.iterdir()))
@@ -391,7 +390,7 @@ async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image
                 # 创建一个新的客户端，避免代理问题
                 with httpx.Client(verify=False, follow_redirects=True, timeout=30.0) as client:
                     char_data = client.get(char_url)
-                
+
                 if char_data.status_code == 200:
                     content_type = char_data.headers.get("Content-Type", "")
                     if "application/json" in content_type:
@@ -408,14 +407,14 @@ async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image
 
     based_w, based_h = 600, 1200
     offset_x, offset_y = 200, 0
-    
+
     # 如果还没有图片数据，尝试下载或使用本地图片
     if char_url and char.char_bytes is None:
         try:
             # 第二次请求：下载实际图片
             with httpx.Client(verify=False, follow_redirects=True, timeout=30.0) as client:
                 response = client.get(char_url)
-            
+
             if response.status_code == 200:
                 char.char_bytes = response.content
                 logger.info(f"[角色图片] {char_name} 下载成功")
@@ -425,7 +424,7 @@ async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image
         except Exception as e:
             logger.error(f"[角色图片] {char_name} 下载异常: {e}")
             char_url = None
-    
+
     # 处理图片
     if char_url and char.char_bytes is not None:
         try:
@@ -435,7 +434,7 @@ async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image
             char_img = None
     else:
         char_img = None
-    
+
     # 如果图片获取失败，使用本地缓存或创建默认图片
     if char_img is None:
         gacha_path = GACHA_IMG_PATH / f"{char_name}.png"
@@ -457,7 +456,7 @@ async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image
         scale_f = "%.3f" % (w / h)
         new_w = math.ceil(based_new_h * float(scale_f))
         new_h = math.ceil(based_new_w / float(scale_f))
-        
+
         if scale_f > based_scale:
             bg_img2 = char_img.resize((new_w, based_new_h), Image.Resampling.LANCZOS)
             x1 = new_w / 2 - based_new_w / 2 + offset_x
@@ -470,14 +469,14 @@ async def get_char_img(char: Character, char_url: Optional[str] = None) -> Image
             y1 = new_h / 2 - based_new_h / 2 + offset_y / 2
             x2 = based_new_w
             y2 = new_h / 2 + based_new_h / 2 - offset_y / 2
-        
+
         char_img = bg_img2.crop((x1, y1, x2, y2))
 
     # 应用遮罩
     char_info_mask = Image.open(TEXT_PATH / "char_info_mask.png")
     char_result = Image.new("RGBA", (based_w, based_h), (0, 0, 0, 0))
     char_result.paste(char_img, (0, 0), char_info_mask)
-    
+
     return char_result
 
 


### PR DESCRIPTION
我个人的Bot部署在Windows服务器上，查询角色面板报错，可能是开了Clash Verge的原因，做了一些改动，目前报错仍有（ 2026-03-04 22:39:26 [error    ] [角色图片] 杜林 获取失败: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1010) ），但能出图了，拙劣修改，请审核/修改后再合并。