### PR TITLE
fix(onebot): 上传文件改用 base64 协议而非本地路径

### DIFF
--- a/GenshinUID/client.py
+++ b/GenshinUID/client.py
@@ -699,23 +699,20 @@ async def onebot_send(
 
     async def to_file(file: str):
         file_name, file_content = file.split('|')
-        path = Path(__file__).resolve().parent / file_name
-        store_file(path, file_content)
         if target_type == 'group':
             await bot.call_api(
                 'upload_group_file',
-                file=str(path.absolute()),
+                file=f'base64://{file_content}',
                 name=file_name,
                 group_id=_target_id,
             )
         else:
             await bot.call_api(
                 'upload_private_file',
-                file=str(path.absolute()),
+                file=f'base64://{file_content}',
                 name=file_name,
                 user_id=_target_id,
             )
-        del_file(path)
 
     async def to_msg(gsmsgs: List[GsMessage]):
         message = []


### PR DESCRIPTION
## 问题

`onebot_send` 里的 `to_file` 会先把 gsuid-core 传来的 base64 文件内容落盘到插件目录下的临时文件，再以本地绝对路径调用 `upload_group_file` / `upload_private_file`，最后删除临时文件。

当 NoneBot（GenshinUID 客户端）与 OneBot 实现（NapCat / Lagrange / LLOneBot 等）运行在**不同容器或不同主机**时，插件写入的本地路径对 OneBot 端并不可见，导致文件上传失败（提示找不到文件）。即便同机运行，落盘 + 删除也是多余的磁盘 IO。

## 改动

`to_file` 改为直接以 `base64://{file_content}` 传递文件内容，去掉落盘与清理逻辑：

```python
async def to_file(file: str):
    file_name, file_content = file.split('|')
    if target_type == 'group':
        await bot.call_api(
            'upload_group_file',
            file=f'base64://{file_content}',
            name=file_name,
            group_id=_target_id,
        )
    else:
        await bot.call_api(
            'upload_private_file',
            file=f'base64://{file_content}',
            name=file_name,
            user_id=_target_id,
        )
```

仅改动 `onebot_send` 内的 `to_file`；`store_file` / `del_file` 仍被其它适配器使用，保持不变。

## 兼容性

- ✅ NapCat / Lagrange / LLOneBot：`upload_group_file` / `upload_private_file` 的 `file` 参数支持 `base64://`
- ⚠️ go-cqhttp：`file` 仅支持本地路径；不过 go-cqhttp 已归档停更
