### PR TITLE
fix: 适配 HoYoLAB 国际服完整角色数据

### DIFF
--- a/GenshinUID/genshinuid_enka/get_enka_img.py
+++ b/GenshinUID/genshinuid_enka/get_enka_img.py
@@ -122,8 +122,8 @@ async def get_char_data(uid: str, char_name: str, enable_self: bool = True) -> U
     else:
         # 国际服用户绑定了自己的 Cookie 时，缓存未命中就从 HoYoLAB
         # 自动同步完整角色列表，避免必须先手动执行强制刷新。
-        from .to_data_by_mys import mys_to_data
         from ..utils.mys_api import mys_api
+        from .to_data_by_mys import mys_to_data
 
         if mys_api.check_os(uid) and await mys_api.get_ck(uid, "OWNER"):
             sync_result = await mys_to_data(uid)

--- a/GenshinUID/genshinuid_enka/get_enka_img.py
+++ b/GenshinUID/genshinuid_enka/get_enka_img.py
@@ -120,7 +120,21 @@ async def get_char_data(uid: str, char_name: str, enable_self: bool = True) -> U
     elif enable_self and char_self_path.exists():
         path = char_self_path
     else:
-        return CHAR_HINT.format(char_name)
+        # 国际服用户绑定了自己的 Cookie 时，缓存未命中就从 HoYoLAB
+        # 自动同步完整角色列表，避免必须先手动执行强制刷新。
+        from .to_data_by_mys import mys_to_data
+        from ..utils.mys_api import mys_api
+
+        if mys_api.check_os(uid) and await mys_api.get_ck(uid, "OWNER"):
+            sync_result = await mys_to_data(uid)
+            if isinstance(sync_result, list) and char_path.exists():
+                path = char_path
+            elif isinstance(sync_result, str):
+                return sync_result
+            else:
+                return CHAR_HINT.format(char_name)
+        else:
+            return CHAR_HINT.format(char_name)
 
     with open(path, "r", encoding="utf8") as fp:
         char_data = json.load(fp)

--- a/GenshinUID/genshinuid_enka/to_data_by_mys.py
+++ b/GenshinUID/genshinuid_enka/to_data_by_mys.py
@@ -55,11 +55,24 @@ async def mys_to_data(uid: str):
     elif isinstance(raw_data, (bytearray, memoryview)):
         return bytes(raw_data)
 
-    char_data = raw_data["avatars"]
-    char_ids = []
-    for i in char_data:
-        char_ids.append(i["id"])
-    data = await mys_api.get_char_detail_data(uid, char_ids)
+    if mys_api.check_os(uid):
+        # 国际服 index 仅适合概览展示；完整角色集合从 character/list
+        # 获取。当前接口会直接返回 {base, weapon, relics, ...} 详情，
+        # 同时兼容仅返回扁平角色列表时再调用 character/detail。
+        char_list_data = await mys_api.get_character_list(uid, "OWNER")
+        if isinstance(char_list_data, int):
+            return get_error(char_list_data)
+        char_data = char_list_data["list"]
+        if char_data and "base" in char_data[0]:
+            data = char_data
+        else:
+            char_ids = [i["id"] for i in char_data]
+            data = await mys_api.get_char_detail_data(uid, char_ids)
+    else:
+        char_data = raw_data["avatars"]
+        char_ids = [i["id"] for i in char_data]
+        data = await mys_api.get_char_detail_data(uid, char_ids)
+
     if isinstance(data, int):
         return get_error(data)
 

--- a/GenshinUID/genshinuid_roleinfo/draw_all_char.py
+++ b/GenshinUID/genshinuid_roleinfo/draw_all_char.py
@@ -8,6 +8,7 @@ from gsuid_core.utils.api.mys.models import IndexData
 
 from ..utils.mys_api import mys_api, get_base_data
 from ..utils.image.image_tools import get_v4_bg
+from ..utils.map.name_covert import avatar_id_to_char_star
 from ..utils.fonts.genshin_fonts import gs_font_28, gs_font_30
 from ..utils.resource.RESOURCE_PATH import (
     CHAR_PATH,
@@ -37,10 +38,14 @@ async def _draw_char_pic(uid: str, raw_data: IndexData):
         return await get_error_img(char_rawdata)
     char_datas = char_rawdata["list"]
 
-    for index, i in enumerate(char_datas):
-        if i["rarity"] > 5:
-            char_datas[index]["rarity"] = 4
-            break
+    for char in char_datas:
+        rarity = char.get("rarity")
+        if rarity is None:
+            try:
+                rarity = int(await avatar_id_to_char_star(str(char["id"])))
+            except (KeyError, TypeError, ValueError):
+                rarity = 4
+        char["rarity"] = min(int(rarity), 5)
 
     char_datas.sort(
         key=lambda x: (

--- a/GenshinUID/genshinuid_roleinfo/draw_all_char.py
+++ b/GenshinUID/genshinuid_roleinfo/draw_all_char.py
@@ -7,8 +7,8 @@ from gsuid_core.utils.image.convert import convert_img
 from gsuid_core.utils.api.mys.models import IndexData
 
 from ..utils.mys_api import mys_api, get_base_data
-from ..utils.image.image_tools import get_v4_bg
 from ..utils.map.name_covert import avatar_id_to_char_star
+from ..utils.image.image_tools import get_v4_bg
 from ..utils.fonts.genshin_fonts import gs_font_28, gs_font_30
 from ..utils.resource.RESOURCE_PATH import (
     CHAR_PATH,

--- a/GenshinUID/utils/api/mys/mys_api.py
+++ b/GenshinUID/utils/api/mys/mys_api.py
@@ -163,15 +163,22 @@ class GsMysAPI(_MysApi):
         return data
 
     @gs_cache(360)
-    async def get_char_detail_data(self, uid: str, char_id_list: List[str]) -> Union[List[Character], int]:
+    async def get_char_detail_data(
+        self,
+        uid: str,
+        char_id_list: List[int],
+    ) -> Union[List[Character], int]:
         server_id = self.RECOGNIZE_SERVER.get(uid[0], "cn_gf01")
-        HEADER = deepcopy(self._HEADER)
+        is_os = self.check_os(uid)
+        HEADER = deepcopy(self._HEADER_OS if is_os else self._HEADER)
         ck = await self.get_ck(uid, "OWNER")
         if ck is None:
             return -51
         HEADER["Cookie"] = ck
+        if is_os:
+            HEADER["DS"] = generate_os_ds()
 
-        base = RECORD_BASE_OS if self.check_os(uid) else RECORD_BASE
+        base = RECORD_BASE_OS if is_os else RECORD_BASE
         data = await self._mys_request(
             char_detail_url,
             "POST",
@@ -182,6 +189,8 @@ class GsMysAPI(_MysApi):
                 "character_ids": char_id_list,
             },
             base_url=base,
+            use_proxy=is_os,
+            game_name="gs",
         )
 
         if isinstance(data, Dict):


### PR DESCRIPTION
## 背景

HoYoLAB 国际服角色接口当前返回 `{base, weapon, relics, ...}` 的嵌套详情结构，而部分 GenshinUID 绘图逻辑仍按国服扁平角色结构读取 `rarity`、`fetter` 等字段，导致执行 `gs查询` 或 `gs角色列表` 时出现 `KeyError`。

此外，`gs查询角色名` 只读取本地面板缓存。即使用户已经绑定自己的国际服 Cookie，未经过 `gs强制刷新` 的角色仍然无法查询。

本 PR 配合 [Genshin-bots/gsuid_core#266](https://github.com/Genshin-bots/gsuid_core/pull/266) 中新增的国际服认证及完整角色列表支持使用。

## 修正内容

### 角色列表兼容

- 兼容国际服嵌套角色数据。
- 对缺失的角色稀有度使用本地角色映射兜底。
- 保证列表排序和绘图所需的角色、命座、好感及武器字段可用。

### 国际服完整角色同步

- 国际服不再只使用 `index` 中的展示角色。
- 使用用户自己的 Cookie 获取完整角色列表。
- 当列表接口已经返回完整 `{base, weapon, relics, ...}` 详情时直接复用，避免重复请求。
- 同时兼容列表接口只返回基础角色数据时继续调用 `character/detail`。

### 按角色查询

- 国际服用户执行 `gs查询角色名` 且本地缓存未命中时，自动从 HoYoLAB 同步完整角色数据并继续本次查询。
- 仅在国际服 UID 且存在用户自己的 Cookie 时触发。
- 未绑定 Cookie 或国服账号继续保持原有行为。
- 同步失败时返回实际 API 错误信息，便于排查。

### 国际服详情请求

- 国际服 `character/detail` 使用对应的 HoYoLAB Header、DS、代理和游戏类型。
- 国服继续使用原有请求头和请求路径。

## 兼容性

- 国际服逻辑通过 UID 区域判断单独启用。
- 未修改国服角色查询、Enka 刷新及现有缓存文件格式。
- 未引入新的第三方依赖。

## 验证

- 使用实际国际服响应样本检查了 104 个角色的结构和绘图所需字段。
- 对 4 个修改文件执行了 AST 语法检查。
- 执行了 `git diff --check`。
